### PR TITLE
Load MailerLite from first-party vendor script with build-time sync fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "dev": "concurrently \"npm:dev:css\" \"npm:dev:site\"",
     "dev:css": "tailwindcss -i ./src/styles/global.css -o ./public/assets/site.css --watch",
     "dev:site": "eleventy --serve --port=4321",
-    "build": "rimraf dist && npm run sync:analytics && npm run build:css && npm run build:site",
+    "build": "rimraf dist && npm run sync:analytics && npm run sync:mailerlite && npm run build:css && npm run build:site",
     "build:css": "tailwindcss -i ./src/styles/global.css -o ./public/assets/site.css --minify",
     "build:site": "eleventy",
     "preview": "http-server dist -a 127.0.0.1 -p 4321 -c-1 --silent",
     "test:e2e": "playwright test",
-    "sync:analytics": "node ./scripts/sync-simple-analytics.mjs"
+    "sync:analytics": "node ./scripts/sync-simple-analytics.mjs",
+    "sync:mailerlite": "node ./scripts/sync-mailerlite.mjs"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",

--- a/public/vendor/mailerlite/universal.js
+++ b/public/vendor/mailerlite/universal.js
@@ -1,0 +1,10 @@
+/*
+ * MailerLite local fallback placeholder.
+ *
+ * The real script is synced at build time by scripts/sync-mailerlite.mjs.
+ * Keeping this file in-repo ensures first-party script loading succeeds even
+ * when third-party networks are blocked during development or CI.
+ */
+window.ml = window.ml || function (...args) {
+  (window.ml.q = window.ml.q || []).push(args);
+};

--- a/scripts/sync-mailerlite.mjs
+++ b/scripts/sync-mailerlite.mjs
@@ -1,0 +1,74 @@
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+const execFileAsync = promisify(execFile);
+
+const SOURCE_URLS = [
+  'https://assets.mailerlite.com/js/universal.js'
+];
+const OUTPUT_PATH = resolve('public/vendor/mailerlite/universal.js');
+
+const downloadWithFetch = async (sourceUrl) => {
+  const response = await fetch(sourceUrl, {
+    headers: {
+      'User-Agent': 'cocoboko-website-build'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return response.text();
+};
+
+const downloadWithCurl = async (sourceUrl) => {
+  const { stdout } = await execFileAsync('curl', ['-fsSL', sourceUrl], {
+    maxBuffer: 5 * 1024 * 1024
+  });
+
+  return stdout;
+};
+
+const downloadScript = async () => {
+  for (const sourceUrl of SOURCE_URLS) {
+    try {
+      return await downloadWithFetch(sourceUrl);
+    } catch {
+      try {
+        return await downloadWithCurl(sourceUrl);
+      } catch {
+        // Continue trying the next source URL.
+      }
+    }
+  }
+
+  return null;
+};
+
+const syncMailerLite = async () => {
+  const script = await downloadScript();
+
+  if (!script) {
+    try {
+      await access(OUTPUT_PATH, fsConstants.F_OK);
+      console.warn(`Could not download MailerLite script. Keeping existing file at ${OUTPUT_PATH}.`);
+      return;
+    } catch {
+      throw new Error('Unable to download MailerLite script from any supported source.');
+    }
+  }
+
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, script, 'utf8');
+  console.log(`Synced MailerLite script to ${OUTPUT_PATH}`);
+};
+
+syncMailerLite().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/src/_includes/components/mailer-lite-header.webc
+++ b/src/_includes/components/mailer-lite-header.webc
@@ -1,6 +1,9 @@
 <script webc:root="override" webc:keep>
   (() => {
-    const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';
+    const MAILERLITE_SCRIPT_URLS = [
+      '/vendor/mailerlite/universal.js',
+      'https://assets.mailerlite.com/js/universal.js'
+    ];
     const MAILERLITE_ACCOUNT_ID = '2010388';
 
     const ml = window.ml || function (...args) {
@@ -14,23 +17,33 @@
       window.dispatchEvent(new CustomEvent('mailerlite:unavailable'));
     };
 
-    const loadMailerLite = async () => {
+    const loadScript = async (scriptUrl) => {
       try {
-        await fetch(MAILERLITE_SCRIPT_URL, { mode: 'no-cors', method: 'GET', cache: 'no-store' });
+        await fetch(scriptUrl, { mode: 'no-cors', method: 'GET', cache: 'no-store' });
       } catch {
-        markUnavailable();
-        return;
+        return false;
       }
 
-      const script = document.createElement('script');
-      script.async = true;
-      script.src = MAILERLITE_SCRIPT_URL;
-      script.onerror = markUnavailable;
-      script.onload = () => {
-        window.ml('account', MAILERLITE_ACCOUNT_ID);
-        window.dispatchEvent(new CustomEvent('mailerlite:ready'));
-      };
-      document.head.append(script);
+      return new Promise((resolve) => {
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = scriptUrl;
+        script.onload = () => resolve(true);
+        script.onerror = () => resolve(false);
+        document.head.append(script);
+      });
+    };
+
+    const loadMailerLite = async () => {
+      for (const scriptUrl of MAILERLITE_SCRIPT_URLS) {
+        if (await loadScript(scriptUrl)) {
+          window.ml('account', MAILERLITE_ACCOUNT_ID);
+          window.dispatchEvent(new CustomEvent('mailerlite:ready'));
+          return;
+        }
+      }
+
+      markUnavailable();
     };
 
     void loadMailerLite();

--- a/tests/production-fallback.spec.ts
+++ b/tests/production-fallback.spec.ts
@@ -6,7 +6,9 @@ test('production HTML ships third-party fallback behaviour for analytics and Mai
 
   const html = await response.text();
 
-  expect(html).toContain("const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';");
+  expect(html).toContain("const MAILERLITE_SCRIPT_URLS = [");
+  expect(html).toContain('/vendor/mailerlite/universal.js');
+  expect(html).toContain('https://assets.mailerlite.com/js/universal.js');
   expect(html).toContain('mailerlite:unavailable');
   expect(html).toContain('data-mailerlite-fallback');
   expect(html).toContain('Newsletter is coming soon!');


### PR DESCRIPTION
### Motivation
- Some browsers and VPNs block third-party JS (MailerLite) causing the embedded newsletter widget to fail, so the loader should prefer a same-origin copy or be available at build time to avoid runtime failures.

### Description
- Updated the MailerLite header loader to use `MAILERLITE_SCRIPT_URLS` and try a same-origin vendor script `/vendor/mailerlite/universal.js` before falling back to the MailerLite CDN and emitting `mailerlite:unavailable` if both fail. 
- Added a build-time sync script `scripts/sync-mailerlite.mjs` that attempts to download `https://assets.mailerlite.com/js/universal.js` (using `fetch` with a `curl` fallback) and writes it to `public/vendor/mailerlite/universal.js` while keeping an existing file if download is blocked. 
- Wired the new sync step into the build pipeline by adding the `sync:mailerlite` npm script and inserting it into the `build` script in `package.json`. 
- Included a simple in-repo placeholder `public/vendor/mailerlite/universal.js` so local/dev/CI builds have a same-origin target even when the CDN is unreachable, and updated the Playwright production-fallback test to assert the new URL array and vendor path. 

### Testing
- Ran `npm run build` which executed `sync:analytics` and `sync:mailerlite` and completed successfully (the MailerLite sync kept the in-repo vendor file when the CDN was blocked). 
- Ran `npm run sync:mailerlite` standalone which could not download the remote script in this environment and logged a warning while preserving the existing vendor file. 
- Ran the Playwright end-to-end test `npm run test:e2e -- tests/production-fallback.spec.ts` and the updated test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de47ec89e48330b77eb947b469d816)