### PR TITLE
Add MailerLite local fallback, sync script, and loader improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "dev": "concurrently \"npm:dev:css\" \"npm:dev:site\"",
     "dev:css": "tailwindcss -i ./src/styles/global.css -o ./public/assets/site.css --watch",
     "dev:site": "eleventy --serve --port=4321",
-    "build": "rimraf dist && npm run sync:analytics && npm run build:css && npm run build:site",
+    "build": "rimraf dist && npm run sync:analytics && npm run sync:mailerlite && npm run build:css && npm run build:site",
     "build:css": "tailwindcss -i ./src/styles/global.css -o ./public/assets/site.css --minify",
     "build:site": "eleventy",
     "preview": "http-server dist -a 127.0.0.1 -p 4321 -c-1 --silent",
     "test:e2e": "playwright test",
-    "sync:analytics": "node ./scripts/sync-simple-analytics.mjs"
+    "sync:analytics": "node ./scripts/sync-simple-analytics.mjs",
+    "sync:mailerlite": "node ./scripts/sync-mailerlite.mjs"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",

--- a/public/vendor/mailerlite/universal.js
+++ b/public/vendor/mailerlite/universal.js
@@ -1,0 +1,11 @@
+/*
+ * MailerLite local fallback placeholder.
+ *
+ * The real script is synced at build time by scripts/sync-mailerlite.mjs.
+ * Keeping this file in-repo ensures first-party script loading succeeds even
+ * when third-party networks are blocked during development or CI.
+ */
+window.__MAILERLITE_VENDOR_STUB__ = true;
+window.ml = window.ml || function (...args) {
+  (window.ml.q = window.ml.q || []).push(args);
+};

--- a/scripts/sync-mailerlite.mjs
+++ b/scripts/sync-mailerlite.mjs
@@ -1,0 +1,74 @@
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+const execFileAsync = promisify(execFile);
+
+const SOURCE_URLS = [
+  'https://assets.mailerlite.com/js/universal.js'
+];
+const OUTPUT_PATH = resolve('public/vendor/mailerlite/universal.js');
+
+const downloadWithFetch = async (sourceUrl) => {
+  const response = await fetch(sourceUrl, {
+    headers: {
+      'User-Agent': 'cocoboko-website-build'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return response.text();
+};
+
+const downloadWithCurl = async (sourceUrl) => {
+  const { stdout } = await execFileAsync('curl', ['-fsSL', sourceUrl], {
+    maxBuffer: 5 * 1024 * 1024
+  });
+
+  return stdout;
+};
+
+const downloadScript = async () => {
+  for (const sourceUrl of SOURCE_URLS) {
+    try {
+      return await downloadWithFetch(sourceUrl);
+    } catch {
+      try {
+        return await downloadWithCurl(sourceUrl);
+      } catch {
+        // Continue trying the next source URL.
+      }
+    }
+  }
+
+  return null;
+};
+
+const syncMailerLite = async () => {
+  const script = await downloadScript();
+
+  if (!script) {
+    try {
+      await access(OUTPUT_PATH, fsConstants.F_OK);
+      console.warn(`Could not download MailerLite script. Keeping existing file at ${OUTPUT_PATH}.`);
+      return;
+    } catch {
+      throw new Error('Unable to download MailerLite script from any supported source.');
+    }
+  }
+
+  await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, script, 'utf8');
+  console.log(`Synced MailerLite script to ${OUTPUT_PATH}`);
+};
+
+syncMailerLite().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/src/_includes/components/mailer-lite-header.webc
+++ b/src/_includes/components/mailer-lite-header.webc
@@ -1,7 +1,11 @@
 <script webc:root="override" webc:keep>
   (() => {
-    const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';
+    const MAILERLITE_SCRIPT_URLS = [
+      '/vendor/mailerlite/universal.js',
+      'https://assets.mailerlite.com/js/universal.js'
+    ];
     const MAILERLITE_ACCOUNT_ID = '2010388';
+    const MAILERLITE_STUB_MARKER = '__MAILERLITE_VENDOR_STUB__';
 
     const ml = window.ml || function (...args) {
       (ml.q = ml.q || []).push(args);
@@ -14,23 +18,42 @@
       window.dispatchEvent(new CustomEvent('mailerlite:unavailable'));
     };
 
-    const loadMailerLite = async () => {
+    const loadScript = async (scriptUrl) => {
       try {
-        await fetch(MAILERLITE_SCRIPT_URL, { mode: 'no-cors', method: 'GET', cache: 'no-store' });
+        await fetch(scriptUrl, { mode: 'no-cors', method: 'GET', cache: 'no-store' });
       } catch {
-        markUnavailable();
-        return;
+        return false;
       }
 
-      const script = document.createElement('script');
-      script.async = true;
-      script.src = MAILERLITE_SCRIPT_URL;
-      script.onerror = markUnavailable;
-      script.onload = () => {
-        window.ml('account', MAILERLITE_ACCOUNT_ID);
-        window.dispatchEvent(new CustomEvent('mailerlite:ready'));
-      };
-      document.head.append(script);
+      return new Promise((resolve) => {
+        delete window[MAILERLITE_STUB_MARKER];
+
+        const script = document.createElement('script');
+        script.async = true;
+        script.src = scriptUrl;
+        script.onload = () => {
+          if (window[MAILERLITE_STUB_MARKER]) {
+            resolve(false);
+            return;
+          }
+
+          resolve(true);
+        };
+        script.onerror = () => resolve(false);
+        document.head.append(script);
+      });
+    };
+
+    const loadMailerLite = async () => {
+      for (const scriptUrl of MAILERLITE_SCRIPT_URLS) {
+        if (await loadScript(scriptUrl)) {
+          window.ml('account', MAILERLITE_ACCOUNT_ID);
+          window.dispatchEvent(new CustomEvent('mailerlite:ready'));
+          return;
+        }
+      }
+
+      markUnavailable();
     };
 
     void loadMailerLite();

--- a/tests/production-fallback.spec.ts
+++ b/tests/production-fallback.spec.ts
@@ -6,7 +6,11 @@ test('production HTML ships third-party fallback behaviour for analytics and Mai
 
   const html = await response.text();
 
-  expect(html).toContain("const MAILERLITE_SCRIPT_URL = 'https://assets.mailerlite.com/js/universal.js';");
+  expect(html).toContain("const MAILERLITE_SCRIPT_URLS = [");
+  expect(html).toContain("const MAILERLITE_STUB_MARKER = '__MAILERLITE_VENDOR_STUB__';");
+  expect(html).toContain('delete window[MAILERLITE_STUB_MARKER];');
+  expect(html).toContain('/vendor/mailerlite/universal.js');
+  expect(html).toContain('https://assets.mailerlite.com/js/universal.js');
   expect(html).toContain('mailerlite:unavailable');
   expect(html).toContain('data-mailerlite-fallback');
   expect(html).toContain('Newsletter is coming soon!');


### PR DESCRIPTION
### Motivation

- Ensure MailerLite can load in development/CI and when third-party networks are blocked by shipping a first-party fallback and automating vendor sync as part of the build. 

### Description

- Add `scripts/sync-mailerlite.mjs` which downloads `https://assets.mailerlite.com/js/universal.js` with `fetch` or `curl` and writes it to `public/vendor/mailerlite/universal.js`.
- Add a minimal local stub at `public/vendor/mailerlite/universal.js` to provide a safe in-repo placeholder during dev/CI.
- Update `src/_includes/components/mailer-lite-header.webc` to try a local vendor script first and then the upstream URL, detect the stub marker, and emit `mailerlite:ready`/`mailerlite:unavailable` events accordingly.
- Wire the sync step into the build by adding `sync:mailerlite` to `package.json` and added the `sync:mailerlite` script entry, plus minor script formatting changes.
- Update `tests/production-fallback.spec.ts` to assert the new loader strings, fallback URLs, and stub marker behavior.

### Testing

- Ran the Playwright tests with `playwright test`, including `tests/production-fallback.spec.ts`, and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de47ec89e48330b77eb947b469d816)